### PR TITLE
Fix montage test and update functions documentation

### DIFF
--- a/docs/api_reference/functions.rst
+++ b/docs/api_reference/functions.rst
@@ -109,8 +109,7 @@ Advanced Processing Functions
    :template: autosummary/function.rst
    :nosignatures:
 
-   autoreject.repair_epochs
-   autoreject.compute_rejection_thresholds
+   autoreject.autoreject_epochs
 
 Visualization Functions
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/unit/utils/test_montage.py
+++ b/tests/unit/utils/test_montage.py
@@ -27,9 +27,9 @@ except ImportError:
 class TestMontageLoading:
     """Test montage loading functionality."""
     
-    @patch('builtins.open', new_callable=mock_open)
-    @patch('yaml.safe_load')
-    def test_load_valid_montages(self, mock_yaml_load, mock_file):
+    @patch('autoclean.utils.montage.resources.files')
+    @patch('autoclean.utils.montage.yaml.safe_load')
+    def test_load_valid_montages(self, mock_yaml_load, mock_resources):
         """Test loading valid montages from configuration."""
         mock_montages = {
             "valid_montages": {
@@ -40,6 +40,11 @@ class TestMontageLoading:
         }
         mock_yaml_load.return_value = mock_montages
         
+        # Mock the resources chain
+        mock_file_path = Mock()
+        mock_file_path.read_text.return_value = "mock yaml content"
+        mock_resources.return_value.joinpath.return_value = mock_file_path
+        
         result = load_valid_montages()
         
         expected = {
@@ -49,7 +54,7 @@ class TestMontageLoading:
         }
         
         assert result == expected
-        mock_file.assert_called_once()
+        mock_resources.assert_called_once()
         mock_yaml_load.assert_called_once()
     
     @patch('builtins.open', side_effect=FileNotFoundError)


### PR DESCRIPTION
- Update test_load_valid_montages to mock resources.files instead of builtins.open
- Add proper mock chain for resources.files().joinpath().read_text()
- Fix test that was failing due to incorrect mocking approach
- Update functions.rst with correct function references